### PR TITLE
Bugfix/83 validation object expects all properties to be set

### DIFF
--- a/src/types/ValidationStrategy.d.ts
+++ b/src/types/ValidationStrategy.d.ts
@@ -3,5 +3,5 @@
 import type { ValidatorFunction } from './ValidatorFunction';
 
 export type ValidationStrategy<T extends Record<string, unknown>> = {
-    [Prop in keyof T]: ValidatorFunction<T[Prop], T> | ValidatorFunction<T[Prop], T>[];
+    [Prop in keyof T]: ValidatorFunction | ValidatorFunction[];
 };

--- a/src/types/Validator.d.ts
+++ b/src/types/Validator.d.ts
@@ -4,5 +4,5 @@ import type { ValidationStrategy } from './ValidationStrategy';
 import type { ValidatorFunction } from './ValidatorFunction';
 
 export type Validator<T extends Record<string, unknown>> = {
-    validate: ValidationStrategy<T>;
+    validate: ValidationStrategy<Partial<T>>;
 };

--- a/tests/Validators.spec.ts
+++ b/tests/Validators.spec.ts
@@ -338,6 +338,8 @@ test('[Validators] ValidateNested correctly validates a deeply nested property',
 
 test('[Validators] ValidateNested correctly validates a value that is not an object', (t) => {
     const value = 'test';
+
+    //@ts-expect-error
     const validator = ValidateNested({ key: 'test' });
 
     t.throws(() => validator(value, 'test-property'));
@@ -345,6 +347,8 @@ test('[Validators] ValidateNested correctly validates a value that is not an obj
 
 test('[Validators] ValidateNested correctly validates a value that is an empty object', (t) => {
     const value = {};
+
+    //@ts-expect-error
     const validator = ValidateNested({ key: 'test' });
 
     t.throws(() => validator(value, 'test-property'));


### PR DESCRIPTION
## Description

Changed the type implementation for collection validation to enable passing partial validation objects.

## Changes Made

- Changed the passed generic type for the object that is validated to a partial
- Removed Generics on Validator Functions to enable type inference

## Related Issues

[Validation Object expects all properties to be set #83](https://github.com/IamSebastianDev/flotsam/issues/83)

## Checklist

Please check off the following items by adding an `x` inside the brackets:

- [X] I have read and followed the contributing guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests to cover my changes.
- [X] I have run the tests and they pass.
- [X] I have formatted my code according to the project's style guide.

## Performance

-

## Accessibility

-

## Additional Information

-