### PR TITLE
chore: update ci to remove node 16 check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        node-version: [16.x, 18.x]
+        node-version: [18.x]
     runs-on: ${{matrix.os}} 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

This PR updates the CI workflow, so that node v.16 is no longer used for tests. This will reduce the github action workload as well as enable updating DevDependencies to newer versions.

## Related Issues

This PR will close issue #88 

## Checklist

Please check off the following items by adding an `x` inside the brackets:

- [X] I have read and followed the contributing guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests to cover my changes.
- [X] I have run the tests and they pass.
- [X] I have formatted my code according to the project's style guide.
- [X] I have added any necessary dependencies to the `package.json` file.

## Performance

-

## Accessibility

-
## Additional Information

-